### PR TITLE
A schedule of upcoming talks

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -21,6 +21,11 @@ url = "/time-and-place"
 weight = 2
 
 [[menu.main]]
+name = "Schedule"
+url = "/schedule"
+weight = 3
+
+[[menu.main]]
 name = "About"
 url = "/about"
-weight = 3
+weight = 4

--- a/content/schedule.md
+++ b/content/schedule.md
@@ -1,0 +1,27 @@
+---
+title: "Schedule"
+date: 2023-02-10T11:19:01-06:00
+draft: false
+---
+
+# Upcoming
+
+## 2023-03-07T18:00:00-06:00 - First Meeting
+
+Welcome to our first meeting! On the agenda we have:
+
+- Introductions
+- Administrative business
+- A talk from Ben
+
+If you want to give a talk, or want to build an idea into a talk we'll
+also spend some time filling out our schedule.
+
+## 2023-04-04T18:00:00-06:00 - Google's Maglev Paper
+
+Aaron Lee will present about [Maglev: A Fast and Reliable Software
+Network Load Balancer](https://research.google/pubs/pub44824/), which
+lays out a way to build a load balancer that serves more traffic than
+any single machine could.
+
+# Archive


### PR DESCRIPTION
We can start a list of upcoming talks on the site. Do you think it's a good idea to suggest people PR their talk ideas? I'm not sure if that could lead to hurt feelings if we say no.
